### PR TITLE
[Jay] week06 미션 제출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'        // 유효성 검증
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/umc/umc_10th/Umc10thApplication.java
+++ b/src/main/java/com/umc/umc_10th/Umc10thApplication.java
@@ -2,7 +2,9 @@ package com.umc.umc_10th;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class Umc10thApplication {
 

--- a/src/main/java/com/umc/umc_10th/domain/home/controller/HomeController.java
+++ b/src/main/java/com/umc/umc_10th/domain/home/controller/HomeController.java
@@ -8,6 +8,7 @@ import com.umc.umc_10th.global.apiPayLoad.code.BaseSuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,11 +19,24 @@ public class HomeController {
     private final HomeService homeService;
 
     @GetMapping("/summary")
-    public ApiResponse<HomeResDTO.Summary> getHomeSummary() {
+    public ApiResponse<HomeResDTO.Summary> getHomeSummary(
+            @RequestParam Long memberId,
+            @RequestParam Long regionId
+    ) {
+        return ApiResponse.onSuccess(HomeSuccessCode.HOME_SUMMARY_SUCCESS,
+                homeService.getHomeSummary(memberId, regionId));
+    }
+
+    @GetMapping("/missions")
+    public ApiResponse<HomeResDTO.HomeMissionList> getHomeMissions(
+            @RequestParam Long regionId,
+            @RequestParam (defaultValue = "0") int page,
+            @RequestParam (defaultValue = "10") int size
+    ) {
 
         BaseSuccessCode code = HomeSuccessCode.HOME_SUMMARY_SUCCESS;
 
-        return ApiResponse.onSuccess(code, homeService.getHomeSummary()
+        return ApiResponse.onSuccess(code, homeService.getHomeMissions(regionId, page, size)
         );
     }
 }

--- a/src/main/java/com/umc/umc_10th/domain/home/dto/HomeResDTO.java
+++ b/src/main/java/com/umc/umc_10th/domain/home/dto/HomeResDTO.java
@@ -1,5 +1,8 @@
 package com.umc.umc_10th.domain.home.dto;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 public class HomeResDTO {
 
     public record Summary(
@@ -10,6 +13,29 @@ public class HomeResDTO {
             Integer goalCount,
             Integer bonusPoint,
             Integer progressRate
+    ) {}
+
+    public record HomeMissionList(
+            List<HomeMissionItem> missions,
+            PageInfo pageInfo
+    ) {}
+
+    public record HomeMissionItem(
+            Long missionId,
+            Long storeId,
+            String storeName,
+            String foodCategory,
+            Long missionCondition,
+            Long rewardPoint,
+            LocalDateTime deadline
+    ) {}
+
+    public record PageInfo(
+            int page,
+            int size,
+            long totalElements,
+            int totalPages,
+            boolean hasNext
     ) {}
 
 }

--- a/src/main/java/com/umc/umc_10th/domain/home/service/HomeService.java
+++ b/src/main/java/com/umc/umc_10th/domain/home/service/HomeService.java
@@ -1,14 +1,87 @@
 package com.umc.umc_10th.domain.home.service;
 
 import com.umc.umc_10th.domain.home.dto.HomeResDTO;
+import com.umc.umc_10th.domain.member.entity.Member;
+import com.umc.umc_10th.domain.member.exception.code.MemberErrorCode;
+import com.umc.umc_10th.domain.member.repository.MemberRepository;
+import com.umc.umc_10th.domain.mission.entity.Mission;
+import com.umc.umc_10th.domain.mission.entity.mapping.MemberMission;
+import com.umc.umc_10th.domain.mission.enums.MissionStatus;
+import com.umc.umc_10th.domain.mission.repository.MemberMissionRepository;
+import com.umc.umc_10th.domain.mission.repository.MissionRepository;
+import com.umc.umc_10th.domain.review.exception.code.ReviewErrorCode;
+import com.umc.umc_10th.domain.store.entity.Region;
+import com.umc.umc_10th.domain.store.repository.RegionRepository;
+import com.umc.umc_10th.global.apiPayLoad.exception.ProjectException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class HomeService {
 
-    public HomeResDTO.Summary getHomeSummary() {
-        return null;
+    private final MissionRepository missionRepository;
+    private final MemberRepository memberRepository;
+    private final RegionRepository regionRepository;
+    private final MemberMissionRepository memberMissionRepository;
+
+    public HomeResDTO.Summary getHomeSummary(Long memberId, Long regionId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ProjectException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Region region = regionRepository.findById(regionId)
+                .orElseThrow(() -> new ProjectException(ReviewErrorCode.REGION_NOT_FOUND));
+
+        int completedCount = memberMissionRepository.countByMemberIdAndStatus(
+                memberId,
+                MissionStatus.DONE
+        );
+
+        int goalCount = 10;
+        int bonusPoint = 1000;
+        int progressRate = (int) ((completedCount / (double) goalCount) * 100);
+
+        return new HomeResDTO.Summary(
+                region.getId(),
+                region.getName(),
+                member.getPoint().intValue(),
+                completedCount,
+                goalCount,
+                bonusPoint,
+                progressRate
+        );
+    }
+
+    public HomeResDTO.HomeMissionList getHomeMissions(Long regionId, int page, int size) {
+
+        Page<MemberMission> memberMissions =
+                memberMissionRepository.findAvailableMissions(
+                        regionId,
+                        PageRequest.of(page, size)
+                );
+
+        return new HomeResDTO.HomeMissionList(
+                memberMissions.getContent().stream()
+                        .map(mm -> new HomeResDTO.HomeMissionItem(
+                                mm.getMission().getId(),
+                                mm.getMission().getStore().getId(),
+                                mm.getMission().getStore().getName(),
+                                mm.getMission().getStore().getFood().getCategory().name(),
+                                mm.getMission().getCondition(),
+                                mm.getMission().getPoint(),
+                                mm.getMission().getDeadline()
+                        ))
+                        .toList(),
+                new HomeResDTO.PageInfo(
+                        memberMissions.getNumber(),
+                        memberMissions.getSize(),
+                        memberMissions.getTotalElements(),
+                        memberMissions.getTotalPages(),
+                        memberMissions.hasNext()
+                )
+        );
     }
 }

--- a/src/main/java/com/umc/umc_10th/domain/home/service/HomeService.java
+++ b/src/main/java/com/umc/umc_10th/domain/home/service/HomeService.java
@@ -4,7 +4,6 @@ import com.umc.umc_10th.domain.home.dto.HomeResDTO;
 import com.umc.umc_10th.domain.member.entity.Member;
 import com.umc.umc_10th.domain.member.exception.code.MemberErrorCode;
 import com.umc.umc_10th.domain.member.repository.MemberRepository;
-import com.umc.umc_10th.domain.mission.entity.Mission;
 import com.umc.umc_10th.domain.mission.entity.mapping.MemberMission;
 import com.umc.umc_10th.domain.mission.enums.MissionStatus;
 import com.umc.umc_10th.domain.mission.repository.MemberMissionRepository;
@@ -12,7 +11,7 @@ import com.umc.umc_10th.domain.mission.repository.MissionRepository;
 import com.umc.umc_10th.domain.review.exception.code.ReviewErrorCode;
 import com.umc.umc_10th.domain.store.entity.Region;
 import com.umc.umc_10th.domain.store.repository.RegionRepository;
-import com.umc.umc_10th.global.apiPayLoad.exception.ProjectException;
+import com.umc.umc_10th.global.apiPayLoad.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -30,10 +29,10 @@ public class HomeService {
     public HomeResDTO.Summary getHomeSummary(Long memberId, Long regionId) {
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ProjectException(MemberErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         Region region = regionRepository.findById(regionId)
-                .orElseThrow(() -> new ProjectException(ReviewErrorCode.REGION_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ReviewErrorCode.REGION_NOT_FOUND));
 
         int completedCount = memberMissionRepository.countByMemberIdAndStatus(
                 memberId,

--- a/src/main/java/com/umc/umc_10th/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/controller/MemberController.java
@@ -7,10 +7,7 @@ import com.umc.umc_10th.domain.member.service.MemberService;
 import com.umc.umc_10th.global.apiPayLoad.ApiResponse;
 import com.umc.umc_10th.global.apiPayLoad.code.BaseSuccessCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,5 +22,12 @@ public class MemberController {
 
         BaseSuccessCode code = MemberSuccessCode.OK;
         return ApiResponse.onSuccess(code, memberService.signUp(request));
+    }
+
+    @GetMapping("/mypage")
+    public ApiResponse<MemberResDTO.MyPage> getMyPage(@RequestParam Long memberId) {
+
+        BaseSuccessCode code = MemberSuccessCode.OK;
+        return ApiResponse.onSuccess(code, memberService.getMyPage(memberId));
     }
 }

--- a/src/main/java/com/umc/umc_10th/domain/member/dto/MemberResDTO.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/dto/MemberResDTO.java
@@ -1,5 +1,6 @@
 package com.umc.umc_10th.domain.member.dto;
 
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDateTime;
@@ -13,4 +14,15 @@ public class MemberResDTO {
             @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
             LocalDateTime createdAt
     ){}
+
+    // 마이페이지
+    public record MyPage(
+            Long memberId,
+            String nickname,
+            String email,
+            String phone,
+            Boolean isPhoneVerified,
+            Long point,
+            String profileUrl
+    ) {}
 }

--- a/src/main/java/com/umc/umc_10th/domain/member/entity/Food.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/entity/Food.java
@@ -18,6 +18,7 @@ public class Food {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "food_id")
     private Long id;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/umc/umc_10th/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/entity/Member.java
@@ -2,11 +2,12 @@ package com.umc.umc_10th.domain.member.entity;
 
 import com.umc.umc_10th.domain.member.enums.Gender;
 import com.umc.umc_10th.domain.member.enums.SocialType;
-import com.umc.umc_10th.domain.member.enums.Address;
+import com.umc.umc_10th.domain.member.enums.RegionType;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -19,12 +20,13 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
     private Long id;
 
     @Column(name = "nickname", nullable = false, length = 50)
     private String nickname;
 
-    @Column(name = "email", unique = true, length = 100, nullable = true)
+    @Column(name = "email", unique = true, length = 100, nullable = false)
     private String email;
 
     @Enumerated(EnumType.STRING)
@@ -44,8 +46,8 @@ public class Member {
     private Boolean isActive = true;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "address", length = 20)
-    private Address address;
+    @Column(name = "region", length = 20)
+    private RegionType region;
 
     @Column(name = "address_detail", length = 255)
     private String addressDetail;
@@ -56,4 +58,16 @@ public class Member {
     @Enumerated(EnumType.STRING)
     @Column(name = "social_type", length = 20, nullable = true)
     private SocialType socialType;
+
+    @Column(name = "social_uid", length = 255, nullable = false)
+    private String socialUid;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 }

--- a/src/main/java/com/umc/umc_10th/domain/member/entity/Term.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/entity/Term.java
@@ -1,4 +1,29 @@
 package com.umc.umc_10th.domain.member.entity;
 
+import com.umc.umc_10th.domain.member.enums.TermType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "term")
 public class Term {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "term_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "name", nullable = false)
+    private TermType name;
+
+    // 필수 동의
+    @Column(name = "is_required", nullable = false)
+    private boolean isRequired;
+
 }

--- a/src/main/java/com/umc/umc_10th/domain/member/entity/mapping/MemberFood.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/entity/mapping/MemberFood.java
@@ -1,4 +1,30 @@
 package com.umc.umc_10th.domain.member.entity.mapping;
 
+import com.umc.umc_10th.domain.member.entity.Food;
+import com.umc.umc_10th.domain.member.entity.Member;
+import com.umc.umc_10th.domain.member.enums.FoodCategory;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "member_food")
 public class MemberFood {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_food_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_id", nullable = false)
+    private Food food;
 }

--- a/src/main/java/com/umc/umc_10th/domain/member/entity/mapping/MemberTerm.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/entity/mapping/MemberTerm.java
@@ -1,4 +1,34 @@
 package com.umc.umc_10th.domain.member.entity.mapping;
 
+import com.umc.umc_10th.domain.member.entity.Member;
+import com.umc.umc_10th.domain.member.entity.Term;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "member_term")
 public class MemberTerm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_term_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "term_id", nullable = false)
+    private Term term;
+
+    @Column(name = "agree_at", nullable = false)
+    private LocalDateTime agreeAt;
 }

--- a/src/main/java/com/umc/umc_10th/domain/member/enums/RegionType.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/enums/RegionType.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum Address {
+public enum RegionType {
 
     GANGNAMGU("강남구"),
     GANGDONGGU("강동구"),

--- a/src/main/java/com/umc/umc_10th/domain/member/enums/TermType.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/enums/TermType.java
@@ -1,0 +1,16 @@
+package com.umc.umc_10th.domain.member.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TermType {
+    AGE("만 14세 이상"),
+    SERVICE("서비스 이용 약관"),
+    PRIVACY("개인 정보 처리 방침"),
+    LOCATION("위치 정보 제공"),
+    MARKETING("마케팅 수신 동의");
+
+    private final String description;
+}

--- a/src/main/java/com/umc/umc_10th/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/exception/code/MemberErrorCode.java
@@ -1,4 +1,17 @@
 package com.umc.umc_10th.domain.member.exception.code;
 
-public enum MemberErrorCode {
+import com.umc.umc_10th.global.apiPayLoad.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements BaseErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E-404-01", "해당 회원을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/umc/umc_10th/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/service/MemberService.java
@@ -2,7 +2,10 @@ package com.umc.umc_10th.domain.member.service;
 
 import com.umc.umc_10th.domain.member.dto.MemberReqDTO;
 import com.umc.umc_10th.domain.member.dto.MemberResDTO;
+import com.umc.umc_10th.domain.member.entity.Member;
+import com.umc.umc_10th.domain.member.exception.code.MemberErrorCode;
 import com.umc.umc_10th.domain.member.repository.MemberRepository;
+import com.umc.umc_10th.global.apiPayLoad.exception.ProjectException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +15,23 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
-    public final MemberResDTO.SignUp signUp(MemberReqDTO.SignUp request) {
+    public MemberResDTO.SignUp signUp(MemberReqDTO.SignUp request) {
         return null;
+    }
+
+    public MemberResDTO.MyPage getMyPage(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ProjectException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        return new MemberResDTO.MyPage(
+                member.getId(),
+                member.getNickname(),
+                member.getEmail(),
+                member.getPhone(),
+                member.getPhone() != null,
+                member.getPoint(),
+                null
+        );
     }
 }

--- a/src/main/java/com/umc/umc_10th/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/service/MemberService.java
@@ -5,7 +5,7 @@ import com.umc.umc_10th.domain.member.dto.MemberResDTO;
 import com.umc.umc_10th.domain.member.entity.Member;
 import com.umc.umc_10th.domain.member.exception.code.MemberErrorCode;
 import com.umc.umc_10th.domain.member.repository.MemberRepository;
-import com.umc.umc_10th.global.apiPayLoad.exception.ProjectException;
+import com.umc.umc_10th.global.apiPayLoad.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +22,7 @@ public class MemberService {
     public MemberResDTO.MyPage getMyPage(Long memberId) {
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ProjectException(MemberErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         return new MemberResDTO.MyPage(
                 member.getId(),

--- a/src/main/java/com/umc/umc_10th/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/umc/umc_10th/domain/mission/controller/MissionController.java
@@ -18,20 +18,22 @@ public class MissionController {
 
     @GetMapping("/in-progress")
     public ApiResponse<MissionResDTO.MissionList> getInProgressMissions(
+            @RequestParam Long memberId,
             @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) int size
     ) {
-        BaseSuccessCode code = MissionSuccessCode.MISSION_IN_PROGRESS_LIST_SUCCESS; // 성공 코드 연결
-        return ApiResponse.onSuccess(code, missionService.getInProgressMissions(page, size));
+        BaseSuccessCode code = MissionSuccessCode.MISSION_IN_PROGRESS_LIST_SUCCESS;
+        return ApiResponse.onSuccess(code, missionService.getInProgressMissions(memberId, page, size));
     }
 
     @GetMapping("/completed")
     public ApiResponse<MissionResDTO.MissionList> getCompletedMissions(
+            @RequestParam Long memberId,
             @RequestParam(defaultValue = "0") @Min(0) int page,
             @RequestParam(defaultValue = "10") @Min(1) int size
     ) {
         BaseSuccessCode code = MissionSuccessCode.MISSION_COMPLETED_LIST_SUCCESS;
-        return ApiResponse.onSuccess(code, missionService.getCompletedMissions(page, size));
+        return ApiResponse.onSuccess(code, missionService.getCompletedMissions(memberId, page, size));
     }
 
     @PutMapping("/{userMissionId}/success")

--- a/src/main/java/com/umc/umc_10th/domain/mission/dto/MissionResDTO.java
+++ b/src/main/java/com/umc/umc_10th/domain/mission/dto/MissionResDTO.java
@@ -6,14 +6,13 @@ import java.util.List;
 public class MissionResDTO {
 
     public record MissionItem(
-            Long userMissionId,
+            Long memberMissionId,
             Long missionId,
             String storeName,
             String title,
             String description,
-            String missionType,
-            Integer targetAmount,
-            Integer rewardPoint,
+            Long condition,
+            Long rewardPoint,
             String status,
             LocalDateTime challengedAt,
             LocalDateTime completedAt

--- a/src/main/java/com/umc/umc_10th/domain/mission/entity/Mission.java
+++ b/src/main/java/com/umc/umc_10th/domain/mission/entity/Mission.java
@@ -1,6 +1,7 @@
 package com.umc.umc_10th.domain.mission.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.umc.umc_10th.domain.store.entity.Store;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,11 +20,17 @@ public class Mission {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "title")
+    private String title;
+
     @Column(name = "point", nullable = false)
     private Long point;
 
     @Column(name = "mission_condition", nullable = false)
-    private String condition;
+    private Long condition;
+
+    @Column(name = "content")
+    private String content;
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @Column(name = "deadline", nullable = false)

--- a/src/main/java/com/umc/umc_10th/domain/mission/entity/mapping/MemberMission.java
+++ b/src/main/java/com/umc/umc_10th/domain/mission/entity/mapping/MemberMission.java
@@ -1,4 +1,42 @@
 package com.umc.umc_10th.domain.mission.entity.mapping;
 
+import com.umc.umc_10th.domain.member.entity.Member;
+import com.umc.umc_10th.domain.mission.entity.Mission;
+import com.umc.umc_10th.domain.mission.enums.MissionStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "member_mission")
 public class MemberMission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_mission_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id", nullable = false)
+    private Mission mission;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private MissionStatus status;
+
+    @Column(name = "challenged_at", nullable = false)
+    private LocalDateTime challengedAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
 }

--- a/src/main/java/com/umc/umc_10th/domain/mission/enums/MissionStatus.java
+++ b/src/main/java/com/umc/umc_10th/domain/mission/enums/MissionStatus.java
@@ -1,0 +1,5 @@
+package com.umc.umc_10th.domain.mission.enums;
+
+public enum MissionStatus {
+    NOT_STARTED, IN_PROGRESS, DONE, CANCELLED
+}

--- a/src/main/java/com/umc/umc_10th/domain/mission/repository/MemberMissionRepository.java
+++ b/src/main/java/com/umc/umc_10th/domain/mission/repository/MemberMissionRepository.java
@@ -1,0 +1,29 @@
+package com.umc.umc_10th.domain.mission.repository;
+
+import com.umc.umc_10th.domain.mission.entity.mapping.MemberMission;
+import com.umc.umc_10th.domain.mission.enums.MissionStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MemberMissionRepository extends JpaRepository<MemberMission, Long> {
+
+    Page<MemberMission> findByMemberIdAndStatus(Long memberId, MissionStatus status, Pageable pageable);
+    int countByMemberIdAndStatus(Long memberId, MissionStatus status);
+
+    @Query("""
+        SELECT mm FROM MemberMission mm
+        JOIN FETCH mm.mission m
+        JOIN FETCH m.store s
+        JOIN FETCH s.food f
+        WHERE s.region.id = :regionId
+        AND (mm.status = 'NOT_STARTED' OR mm.status = 'IN_PROGRESS')
+        AND m.deadline > CURRENT_TIMESTAMP
+    """)
+    Page<MemberMission> findAvailableMissions(
+            @Param("regionId") Long regionId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/umc/umc_10th/domain/mission/repository/MissionRepository.java
+++ b/src/main/java/com/umc/umc_10th/domain/mission/repository/MissionRepository.java
@@ -1,7 +1,11 @@
 package com.umc.umc_10th.domain.mission.repository;
 
 import com.umc.umc_10th.domain.mission.entity.Mission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionRepository extends JpaRepository<Mission, Long> {
+
+    Page<Mission> findByStoreRegionId(Long regionId, Pageable pageable);
 }

--- a/src/main/java/com/umc/umc_10th/domain/mission/service/MissionService.java
+++ b/src/main/java/com/umc/umc_10th/domain/mission/service/MissionService.java
@@ -1,28 +1,79 @@
 package com.umc.umc_10th.domain.mission.service;
 
 import com.umc.umc_10th.domain.mission.dto.MissionResDTO;
-import com.umc.umc_10th.domain.mission.repository.MissionRepository;
+import com.umc.umc_10th.domain.mission.entity.mapping.MemberMission;
+import com.umc.umc_10th.domain.mission.enums.MissionStatus;
+import com.umc.umc_10th.domain.mission.repository.MemberMissionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MissionService {
 
-    private final MissionRepository missionRepository;
+    private final MemberMissionRepository memberMissionRepository;
 
-    // 추후 미션 중 / 미션 완료 로직 개발
-    public MissionResDTO.MissionList getInProgressMissions(int page, int size) {
-        return null;
+    public MissionResDTO.MissionList getInProgressMissions(Long memberId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<MemberMission> memberMissions =
+                memberMissionRepository.findByMemberIdAndStatus(
+                        memberId,
+                        MissionStatus.IN_PROGRESS,
+                        pageable
+                );
+
+        return toMissionList(memberMissions);
     }
 
-    public MissionResDTO.MissionList getCompletedMissions(int page, int size){
-        return null;
+    public MissionResDTO.MissionList getCompletedMissions(Long memberId, int page, int size){
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<MemberMission> memberMissions =
+                memberMissionRepository.findByMemberIdAndStatus(
+                        memberId,
+                        MissionStatus.DONE,
+                        pageable
+                );
+
+        return toMissionList(memberMissions);
     }
 
     public MissionResDTO.MissionSuccess completeMission(Long userMissionId) {
         return null;
+    }
+
+    private MissionResDTO.MissionList toMissionList(Page<MemberMission> memberMissions) {
+
+        List<MissionResDTO.MissionItem> missions = memberMissions.getContent().stream()
+                .map(memberMission -> new MissionResDTO.MissionItem(
+                        memberMission.getId(),
+                        memberMission.getMission().getId(),
+                        memberMission.getMission().getStore().getName(),
+                        memberMission.getMission().getTitle(),
+                        memberMission.getMission().getContent(),
+                        memberMission.getMission().getCondition(),
+                        memberMission.getMission().getPoint(),
+                        memberMission.getStatus().name(),
+                        memberMission.getChallengedAt(),
+                        memberMission.getCompletedAt()
+                ))
+                .toList();
+
+        MissionResDTO.PageInfo pageInfo = new MissionResDTO.PageInfo(
+                memberMissions.getNumber(),
+                memberMissions.getSize(),
+                memberMissions.getTotalElements(),
+                memberMissions.getTotalPages(),
+                memberMissions.hasNext()
+        );
+
+        return new MissionResDTO.MissionList(missions, pageInfo);
     }
 }

--- a/src/main/java/com/umc/umc_10th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/controller/ReviewController.java
@@ -8,11 +8,13 @@ import com.umc.umc_10th.global.apiPayLoad.ApiResponse;
 import com.umc.umc_10th.global.apiPayLoad.code.BaseSuccessCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/reviews")
+@Validated
 public class ReviewController {
 
     private final ReviewService reviewService;
@@ -21,7 +23,7 @@ public class ReviewController {
     public ApiResponse<ReviewResDTO.CreateReviewResponse> createReview(
             @PathVariable Long storeId,
             @RequestParam Long memberId,
-            @RequestBody @Valid ReviewReqDTO.CreateReview request) {
+            @Valid @RequestBody ReviewReqDTO.CreateReviewRequest request) {
 
         BaseSuccessCode code = ReviewSuccessCode.OK;
         return ApiResponse.onSuccess(code, reviewService.createReview(storeId, memberId,request));

--- a/src/main/java/com/umc/umc_10th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/controller/ReviewController.java
@@ -20,10 +20,11 @@ public class ReviewController {
     @PostMapping("/{storeId}")
     public ApiResponse<ReviewResDTO.CreateReview> createReview(
             @PathVariable Long storeId,
+            @RequestParam Long memberId,
             @RequestBody @Valid ReviewReqDTO.CreateReview request) {
 
         BaseSuccessCode code = ReviewSuccessCode.OK;
-        return ApiResponse.onSuccess(code, reviewService.createReview(request));
+        return ApiResponse.onSuccess(code, reviewService.createReview(storeId, memberId,request));
 
     }
 }

--- a/src/main/java/com/umc/umc_10th/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/controller/ReviewController.java
@@ -18,7 +18,7 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @PostMapping("/{storeId}")
-    public ApiResponse<ReviewResDTO.CreateReview> createReview(
+    public ApiResponse<ReviewResDTO.CreateReviewResponse> createReview(
             @PathVariable Long storeId,
             @RequestParam Long memberId,
             @RequestBody @Valid ReviewReqDTO.CreateReview request) {

--- a/src/main/java/com/umc/umc_10th/domain/review/dto/ReviewReqDTO.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/dto/ReviewReqDTO.java
@@ -1,19 +1,16 @@
 package com.umc.umc_10th.domain.review.dto;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 
 @Getter
 public class ReviewReqDTO {
 
     // 리뷰 작성
-    public record CreateReview(
+    public record CreateReviewRequest(
         @NotNull(message = "평점은 필수 입력입니다.")
-        @Min(value = 0, message = "평점은 0점 이상이어야 합니다.")
-        @Max(value = 5, message = "평점은 5점 이하여야 합니다.")
+        @DecimalMin(value = "0.0", message = "평점은 0점 이상이어야 합니다.")
+        @DecimalMax(value = "5.0", message = "평점은 5점 이하여야 합니다.")
         Double rating,
 
         @NotBlank(message = "리뷰 내용을 작성해 주세요.")

--- a/src/main/java/com/umc/umc_10th/domain/review/dto/ReviewResDTO.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/dto/ReviewResDTO.java
@@ -1,19 +1,12 @@
 package com.umc.umc_10th.domain.review.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-
 import java.time.LocalDateTime;
 
-@Getter
-@Builder
-@AllArgsConstructor
 public class ReviewResDTO {
 
     // 리뷰 작성
-    public record CreateReview(
+    public record CreateReviewResponse(
             Long reviewId,
             Long storeId,
             Long memberId,
@@ -22,3 +15,4 @@ public class ReviewResDTO {
     ) {}
 
 }
+

--- a/src/main/java/com/umc/umc_10th/domain/review/entity/Reply.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/entity/Reply.java
@@ -1,4 +1,22 @@
 package com.umc.umc_10th.domain.review.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "reply")
 public class Reply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reply_id")
+    private Long id;
+
+    @Column(name = "content", length = 255, nullable = false)
+    private String content;
 }

--- a/src/main/java/com/umc/umc_10th/domain/review/entity/Review.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/entity/Review.java
@@ -2,11 +2,13 @@ package com.umc.umc_10th.domain.review.entity;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.umc.umc_10th.domain.member.entity.Member;
-import com.umc.umc_10th.domain.mission.entity.Store;
+import com.umc.umc_10th.domain.store.entity.Store;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -19,6 +21,7 @@ public class Review {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id")
     private Long id;
 
     @Column(name = "content", nullable = false, columnDefinition = "TEXT")
@@ -49,5 +52,11 @@ public class Review {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reply_id")
+    private Reply reply;
+
+    @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
+    private List<ReviewPhoto> reviewPhotos = new ArrayList<>();
 
 }

--- a/src/main/java/com/umc/umc_10th/domain/review/entity/Review.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/entity/Review.java
@@ -3,6 +3,7 @@ package com.umc.umc_10th.domain.review.entity;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.umc.umc_10th.domain.member.entity.Member;
 import com.umc.umc_10th.domain.store.entity.Store;
+import com.umc.umc_10th.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -12,12 +13,11 @@ import java.util.List;
 
 @Entity
 @Getter
-@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
 @Table(name = "review")
-public class Review {
+public class Review extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,14 +29,6 @@ public class Review {
 
     @Column(name = "rating", nullable = false)
     private Double rating;
-
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     @Column(name = "deleted_at")

--- a/src/main/java/com/umc/umc_10th/domain/review/entity/Review.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/entity/Review.java
@@ -46,7 +46,7 @@ public class Review extends BaseEntity {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reply_id")
-    private Reply reply;
+    private ReviewReply reply;
 
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL)
     private List<ReviewPhoto> reviewPhotos = new ArrayList<>();

--- a/src/main/java/com/umc/umc_10th/domain/review/entity/ReviewPhoto.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/entity/ReviewPhoto.java
@@ -1,4 +1,26 @@
 package com.umc.umc_10th.domain.review.entity;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "review_photo")
 public class ReviewPhoto {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_photo_id")
+    private Long id;
+
+    @Column(name = "photo_url", columnDefinition = "TEXT")
+    private String photoUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review;
 }

--- a/src/main/java/com/umc/umc_10th/domain/review/entity/ReviewReply.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/entity/ReviewReply.java
@@ -10,7 +10,7 @@ import lombok.*;
 @NoArgsConstructor
 @Builder
 @Table(name = "reply")
-public class Reply {
+public class ReviewReply {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/umc/umc_10th/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/exception/code/ReviewErrorCode.java
@@ -1,4 +1,21 @@
 package com.umc.umc_10th.domain.review.exception.code;
 
-public enum ReviewErrorCode {
+import com.umc.umc_10th.global.apiPayLoad.code.BaseErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReviewErrorCode implements BaseErrorCode {
+
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "E-404-01", "해당 가게를 찾을 수 없습니다."),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E-404-02", "해당 회원을 찾을 수 없습니다."),
+    REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "E-404-03", "해당 지역을 찾을 수 없습니다."),
+    INVALID_RATING(HttpStatus.BAD_REQUEST, "E-400-01", "별점은 0 ~ 5 사이여야 합니다."),
+    EMPTY_CONTENT(HttpStatus.BAD_REQUEST, "E-400-02", "리뷰 내용은 필수입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/umc/umc_10th/domain/review/exception/code/ReviewErrorCode.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/exception/code/ReviewErrorCode.java
@@ -12,8 +12,7 @@ public enum ReviewErrorCode implements BaseErrorCode {
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "E-404-01", "해당 가게를 찾을 수 없습니다."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E-404-02", "해당 회원을 찾을 수 없습니다."),
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "E-404-03", "해당 지역을 찾을 수 없습니다."),
-    INVALID_RATING(HttpStatus.BAD_REQUEST, "E-400-01", "별점은 0 ~ 5 사이여야 합니다."),
-    EMPTY_CONTENT(HttpStatus.BAD_REQUEST, "E-400-02", "리뷰 내용은 필수입니다.");
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/umc_10th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/service/ReviewService.java
@@ -13,8 +13,6 @@ import com.umc.umc_10th.global.apiPayLoad.exception.ProjectException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
-
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
@@ -23,7 +21,7 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;
 
-    public final ReviewResDTO.CreateReview createReview(
+    public final ReviewResDTO.CreateReviewResponse createReview(
             Long storeId, Long memberId, ReviewReqDTO.CreateReview request){
 
         Store store = storeRepository.findById(storeId)
@@ -32,23 +30,19 @@ public class ReviewService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ProjectException(ReviewErrorCode.MEMBER_NOT_FOUND));
 
-        LocalDateTime now = LocalDateTime.now();
-
         Review review = Review.builder()
                 .store(store)
                 .member(member)
                 .rating(request.rating())
                 .content(request.content())
-                .createdAt(now)
-                .updatedAt(now)
                 .build();
 
         Review savedReview = reviewRepository.save(review);
 
-        return new ReviewResDTO.CreateReview(
+        return new ReviewResDTO.CreateReviewResponse(
                 savedReview.getId(),
-                store.getId(),
-                member.getId(),
+                savedReview.getStore().getId(),
+                savedReview.getMember().getId(),
                 savedReview.getCreatedAt()
         );
     }

--- a/src/main/java/com/umc/umc_10th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/service/ReviewService.java
@@ -9,7 +9,7 @@ import com.umc.umc_10th.domain.review.exception.code.ReviewErrorCode;
 import com.umc.umc_10th.domain.review.repository.ReviewRepository;
 import com.umc.umc_10th.domain.store.entity.Store;
 import com.umc.umc_10th.domain.store.repository.StoreRepository;
-import com.umc.umc_10th.global.apiPayLoad.exception.ProjectException;
+import com.umc.umc_10th.global.apiPayLoad.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,14 +21,14 @@ public class ReviewService {
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;
 
-    public final ReviewResDTO.CreateReviewResponse createReview(
-            Long storeId, Long memberId, ReviewReqDTO.CreateReview request){
+    public ReviewResDTO.CreateReviewResponse createReview(
+            Long storeId, Long memberId, ReviewReqDTO.CreateReviewRequest request){
 
         Store store = storeRepository.findById(storeId)
-                .orElseThrow(() -> new ProjectException(ReviewErrorCode.STORE_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ReviewErrorCode.STORE_NOT_FOUND));
 
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new ProjectException(ReviewErrorCode.MEMBER_NOT_FOUND));
+                .orElseThrow(() -> new CustomException(ReviewErrorCode.MEMBER_NOT_FOUND));
 
         Review review = Review.builder()
                 .store(store)

--- a/src/main/java/com/umc/umc_10th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/service/ReviewService.java
@@ -1,18 +1,55 @@
 package com.umc.umc_10th.domain.review.service;
 
+import com.umc.umc_10th.domain.member.entity.Member;
+import com.umc.umc_10th.domain.member.repository.MemberRepository;
 import com.umc.umc_10th.domain.review.dto.ReviewReqDTO;
 import com.umc.umc_10th.domain.review.dto.ReviewResDTO;
+import com.umc.umc_10th.domain.review.entity.Review;
+import com.umc.umc_10th.domain.review.exception.code.ReviewErrorCode;
 import com.umc.umc_10th.domain.review.repository.ReviewRepository;
+import com.umc.umc_10th.domain.store.entity.Store;
+import com.umc.umc_10th.domain.store.repository.StoreRepository;
+import com.umc.umc_10th.global.apiPayLoad.exception.ProjectException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
+    private final MemberRepository memberRepository;
+    private final StoreRepository storeRepository;
 
-    public final ReviewResDTO.CreateReview createReview(ReviewReqDTO.CreateReview request){
-        return null;
+    public final ReviewResDTO.CreateReview createReview(
+            Long storeId, Long memberId, ReviewReqDTO.CreateReview request){
+
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new ProjectException(ReviewErrorCode.STORE_NOT_FOUND));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ProjectException(ReviewErrorCode.MEMBER_NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        Review review = Review.builder()
+                .store(store)
+                .member(member)
+                .rating(request.rating())
+                .content(request.content())
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
+
+        Review savedReview = reviewRepository.save(review);
+
+        return new ReviewResDTO.CreateReview(
+                savedReview.getId(),
+                store.getId(),
+                member.getId(),
+                savedReview.getCreatedAt()
+        );
     }
 }

--- a/src/main/java/com/umc/umc_10th/domain/store/entity/Region.java
+++ b/src/main/java/com/umc/umc_10th/domain/store/entity/Region.java
@@ -1,0 +1,22 @@
+package com.umc.umc_10th.domain.store.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "region")
+public class Region {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "region_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 20)
+    private String name;
+}

--- a/src/main/java/com/umc/umc_10th/domain/store/entity/Store.java
+++ b/src/main/java/com/umc/umc_10th/domain/store/entity/Store.java
@@ -1,7 +1,7 @@
-package com.umc.umc_10th.domain.mission.entity;
+package com.umc.umc_10th.domain.store.entity;
 
 import com.umc.umc_10th.domain.member.entity.Food;
-import com.umc.umc_10th.domain.mission.enums.Status;
+import com.umc.umc_10th.domain.store.enums.StoreStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -16,20 +16,25 @@ public class Store {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "store_id")
     private Long id;
 
     @Column(name = "name", nullable = false, length = 100)
     private String name;            // 음식점명
 
-    @Column(name= "address", nullable = false)
-    private String address;
+    @Column(name = "manager_number", nullable = false)
+    private Long managerNumber;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name= "region_id", nullable = false)
+    private Region region;
 
     @Column(name = "detail_address")
     private String detailAddress;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 10)
-    private Status Status;
+    private StoreStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "food_id")

--- a/src/main/java/com/umc/umc_10th/domain/store/enums/StoreStatus.java
+++ b/src/main/java/com/umc/umc_10th/domain/store/enums/StoreStatus.java
@@ -1,0 +1,13 @@
+package com.umc.umc_10th.domain.store.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StoreStatus {
+    OPEN("영업 중"),
+    CLOSED("영업 종료");
+
+    private final String description;
+}

--- a/src/main/java/com/umc/umc_10th/domain/store/repository/RegionRepository.java
+++ b/src/main/java/com/umc/umc_10th/domain/store/repository/RegionRepository.java
@@ -1,0 +1,7 @@
+package com.umc.umc_10th.domain.store.repository;
+
+import com.umc.umc_10th.domain.store.entity.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+}

--- a/src/main/java/com/umc/umc_10th/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/umc/umc_10th/domain/store/repository/StoreRepository.java
@@ -1,0 +1,7 @@
+package com.umc.umc_10th.domain.store.repository;
+
+import com.umc.umc_10th.domain.store.entity.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/src/main/java/com/umc/umc_10th/global/apiPayLoad/exception/CustomException.java
+++ b/src/main/java/com/umc/umc_10th/global/apiPayLoad/exception/CustomException.java
@@ -6,6 +6,6 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class ProjectException extends RuntimeException {
+public class CustomException extends RuntimeException {
     private final BaseErrorCode errorCode;
 }

--- a/src/main/java/com/umc/umc_10th/global/apiPayLoad/exception/ExceptionAdvice.java
+++ b/src/main/java/com/umc/umc_10th/global/apiPayLoad/exception/ExceptionAdvice.java
@@ -1,0 +1,40 @@
+package com.umc.umc_10th.global.apiPayLoad.exception;
+
+import com.umc.umc_10th.global.apiPayLoad.ApiResponse;
+import com.umc.umc_10th.global.apiPayLoad.code.GeneralErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    // Validation Error
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request
+    ) {
+        String message = ex.getBindingResult()
+                .getFieldErrors()
+                .get(0)
+                .getDefaultMessage();
+
+        return ResponseEntity
+                .badRequest()
+                .body(ApiResponse.onFailure(
+                        GeneralErrorCode.BAD_REQUEST,
+                        message
+                ));
+    }
+
+}

--- a/src/main/java/com/umc/umc_10th/global/apiPayLoad/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/umc_10th/global/apiPayLoad/handler/GeneralExceptionAdvice.java
@@ -3,7 +3,7 @@ package com.umc.umc_10th.global.apiPayLoad.handler;
 import com.umc.umc_10th.global.apiPayLoad.ApiResponse;
 import com.umc.umc_10th.global.apiPayLoad.code.BaseErrorCode;
 import com.umc.umc_10th.global.apiPayLoad.code.GeneralErrorCode;
-import com.umc.umc_10th.global.apiPayLoad.exception.ProjectException;
+import com.umc.umc_10th.global.apiPayLoad.exception.CustomException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,9 +12,9 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GeneralExceptionAdvice {
 
     // 프로젝트에서 발생한 예외 처리
-    @ExceptionHandler(ProjectException.class)
+    @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<Void>> handleMemberException(
-            ProjectException e
+            CustomException e
     ) {
         BaseErrorCode errorCode = e.getErrorCode();
         return ResponseEntity.status(errorCode.getStatus())

--- a/src/main/java/com/umc/umc_10th/global/entity/BaseEntity.java
+++ b/src/main/java/com/umc/umc_10th/global/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.umc.umc_10th.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
#21 
- 엔티티를 제작하고 매핑까지 완료하기
- 서비스를 만들고 5주차에 제작한 컨트롤러와 연결
---

## 🤔 피드백 받고 싶은 내용, 질문 사항
- 홈 화면 조회 쿼리에서 상단 정보와 미션 목록 조회를 각각 별도의 요청으로 나누어 처리하였습니다. 하나의 API로 묶어 응답하는 방식과 현재처럼 분리하는 방식 중 어떤 구조가 더 적절한지 궁금합니다.
- 예외 처리를 `ProjectException`로 구현해뒀는데 이렇게 해도 괜찮을까요?
---

## ✅ 작업 목록
- [x] 엔티티 제작
- [x] 엔티티 매핑 
- [x] 리뷰 작성하는 서비스, 컨트롤러 구현
  <p align="center">
    <img src="https://github.com/user-attachments/assets/7722a5d5-e340-416c-9515-f0cef55145b3" width="45%" />
    <img src="https://github.com/user-attachments/assets/d8f47ac7-7b36-42b7-8ce4-e6aaa36bec24" width="45%" />
  </p>
- [x] 내가 진행중, 진행 완료한 미션 모아서 보는 쿼리(페이징 포함) 서비스, 컨트롤러 구현
    <img width="2764" height="1206" alt="image" src="https://github.com/user-attachments/assets/4244d436-fbac-4762-adea-04856df94999" />
    <img width="2764" height="1206" alt="image" src="https://github.com/user-attachments/assets/63ae0eb9-4b1a-4f6d-906d-de1c0a87b5f8" />

- [x] 마이 페이지 화면 쿼리 서비스, 컨트롤러 구현
  <img width="2750" height="1108" alt="image" src="https://github.com/user-attachments/assets/a562b629-1f55-4d76-ab22-7721226a6a48" />
- [x] 홈 화면 쿼리 (현재 선택 된 지역에서 도전이 가능한 미션 목록, 페이징 포함) 서비스, 컨트롤러 구현
    <img width="2762" height="864" alt="image" src="https://github.com/user-attachments/assets/bd049154-70ab-495f-be4b-10cf14b53131" />
    <img width="2764" height="1176" alt="image" src="https://github.com/user-attachments/assets/6a4a7d29-72aa-41fa-b07d-75ad74595ccf" />

---

## 📝 기타 참고사항
- 테스트를 위해 member, store, mission 테스트 데이터를 생성하였습니다.
