### PR TITLE
Jay week08

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api:3.0.1'
+
+
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/umc_10th/domain/member/controller/MemberController.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.umc.umc_10th.domain.member.exception.code.MemberSuccessCode;
 import com.umc.umc_10th.domain.member.service.MemberService;
 import com.umc.umc_10th.global.apiPayLoad.ApiResponse;
 import com.umc.umc_10th.global.apiPayLoad.code.BaseSuccessCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,7 +19,7 @@ public class MemberController {
 
     @PostMapping("/signup")
     public ApiResponse<MemberResDTO.SignUp> signup
-            (@RequestBody MemberReqDTO.SignUp request) {
+            (@Valid @RequestBody MemberReqDTO.SignUp request) {
 
         BaseSuccessCode code = MemberSuccessCode.OK;
         return ApiResponse.onSuccess(code, memberService.signUp(request));

--- a/src/main/java/com/umc/umc_10th/domain/member/dto/MemberReqDTO.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/dto/MemberReqDTO.java
@@ -1,6 +1,7 @@
 package com.umc.umc_10th.domain.member.dto;
 
 import com.umc.umc_10th.domain.member.enums.Gender;
+import jakarta.validation.constraints.*;
 
 import java.time.LocalDate;
 
@@ -8,10 +9,23 @@ public class MemberReqDTO {
 
     // 회원 가입
     public record SignUp(
+            @NotBlank(message = "이메일은 필수입니다.")
+            @Email(message = "올바른 이메일 형식이 아닙니다.")
             String email,
+
+            @NotBlank(message = "닉네임은 필수입니다.")
+            @Size(min = 2, max = 20, message = "닉네임은 2자 이상 20자 이하입니다.")
             String nickname,
+
+            @NotNull(message = "성별은 필수입니다.")
             Gender gender,                  // MALE or FEMALE
+
+            @NotNull(message = "생년월일은 필수입니다.")
+            @Past(message = "생년월일은 과거 날짜여야 합니다.")
             LocalDate birth,
+
+            @NotBlank(message = "비밀번호는 필수입니다.")
+            @Size(min = 8, max = 20, message = "비밀번호는 8자 이상 20자 이하입니다.")
             String password
     ) {}
 }

--- a/src/main/java/com/umc/umc_10th/domain/member/dto/MemberReqDTO.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/dto/MemberReqDTO.java
@@ -8,6 +8,7 @@ public class MemberReqDTO {
 
     // 회원 가입
     public record SignUp(
+            String email,
             String nickname,
             Gender gender,                  // MALE or FEMALE
             LocalDate birth,

--- a/src/main/java/com/umc/umc_10th/domain/member/entity/Member.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/entity/Member.java
@@ -3,6 +3,7 @@ package com.umc.umc_10th.domain.member.entity;
 import com.umc.umc_10th.domain.member.enums.Gender;
 import com.umc.umc_10th.domain.member.enums.SocialType;
 import com.umc.umc_10th.domain.member.enums.RegionType;
+import com.umc.umc_10th.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -16,7 +17,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Builder
 @Table(name = "member")
-public class Member {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,6 +43,7 @@ public class Member {
     @Column(name = "password", nullable = false, length = 255)
     private String password;
 
+    @Builder.Default
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = true;
 
@@ -52,21 +54,16 @@ public class Member {
     @Column(name = "address_detail", length = 255)
     private String addressDetail;
 
+    @Builder.Default
     @Column(name = "point", nullable = false)
     private Long point = 0L;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "social_type", length = 20, nullable = true)
+    @Column(name = "social_type", length = 20)
     private SocialType socialType;
 
-    @Column(name = "social_uid", length = 255, nullable = false)
+    @Column(name = "social_uid", length = 255)
     private String socialUid;
-
-    @Column(name = "created_at", nullable = false)
-    private LocalDateTime createdAt;
-
-    @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;

--- a/src/main/java/com/umc/umc_10th/domain/member/exception/code/MemberErrorCode.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/exception/code/MemberErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
 
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E-404-01", "해당 회원을 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "E-404-01", "해당 회원을 찾을 수 없습니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "E-409-01", "이미 사용 중인 이메일입니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "E-409-02", "이미 사용 중인 닉네임입니다.")
+    ;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/umc_10th/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/repository/MemberRepository.java
@@ -4,6 +4,11 @@ import com.umc.umc_10th.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/umc/umc_10th/domain/member/service/MemberService.java
+++ b/src/main/java/com/umc/umc_10th/domain/member/service/MemberService.java
@@ -7,6 +7,7 @@ import com.umc.umc_10th.domain.member.exception.code.MemberErrorCode;
 import com.umc.umc_10th.domain.member.repository.MemberRepository;
 import com.umc.umc_10th.global.apiPayLoad.exception.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,9 +15,33 @@ import org.springframework.stereotype.Service;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public MemberResDTO.SignUp signUp(MemberReqDTO.SignUp request) {
-        return null;
+
+        if (memberRepository.existsByEmail(request.email())) {
+            throw new CustomException(MemberErrorCode.EMAIL_ALREADY_EXISTS);
+        }
+
+        if (memberRepository.existsByNickname(request.nickname())) {
+            throw new CustomException(MemberErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+
+        Member member = Member.builder()
+                .email(request.email())
+                .password(passwordEncoder.encode(request.password()))
+                .nickname(request.nickname())
+                .gender(request.gender())
+                .birth(request.birth())
+                .build();
+
+        Member savedMember = memberRepository.save(member);
+
+        return new MemberResDTO.SignUp(
+                savedMember.getId(),
+                savedMember.getNickname(),
+                savedMember.getCreatedAt()
+        );
     }
 
     public MemberResDTO.MyPage getMyPage(Long memberId) {

--- a/src/main/java/com/umc/umc_10th/domain/review/service/ReviewService.java
+++ b/src/main/java/com/umc/umc_10th/domain/review/service/ReviewService.java
@@ -5,7 +5,6 @@ import com.umc.umc_10th.domain.member.repository.MemberRepository;
 import com.umc.umc_10th.domain.review.dto.ReviewReqDTO;
 import com.umc.umc_10th.domain.review.dto.ReviewResDTO;
 import com.umc.umc_10th.domain.review.entity.Review;
-import com.umc.umc_10th.domain.review.exception.ReviewException;
 import com.umc.umc_10th.domain.review.exception.code.ReviewErrorCode;
 import com.umc.umc_10th.domain.review.repository.ReviewRepository;
 import com.umc.umc_10th.domain.store.entity.Store;
@@ -115,7 +114,7 @@ public class ReviewService {
         try {
             String[] parts = cursor.split("_");
             if (parts.length != 2) {
-                throw new ReviewException(ReviewErrorCode.INVALID_CURSOR);
+                throw new CustomException(ReviewErrorCode.INVALID_CURSOR);
             }
 
             Double rating = Double.parseDouble(parts[0]);
@@ -123,7 +122,7 @@ public class ReviewService {
 
             return new RatingCursor(rating, reviewId);
         } catch (NumberFormatException e){
-            throw new ReviewException(ReviewErrorCode.INVALID_CURSOR);
+            throw new CustomException(ReviewErrorCode.INVALID_CURSOR);
         }
     }
 

--- a/src/main/java/com/umc/umc_10th/global/security/SecurityConfig.java
+++ b/src/main/java/com/umc/umc_10th/global/security/SecurityConfig.java
@@ -1,0 +1,70 @@
+package com.umc.umc_10th.global.security;
+
+import com.umc.umc_10th.global.security.handler.CustomAccessDeniedHandler;
+import com.umc.umc_10th.global.security.handler.CustomAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http
+                .csrf(csrf -> csrf.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+
+                .authorizeHttpRequests(auth -> auth
+                        // 로그인 없이 접근 가능한 Public API
+                        .requestMatchers(
+                                "/users/signup",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**"
+                        ).permitAll()
+
+                        // 그 외 모든 요청은 로그인 필요 (Private API)
+                        .anyRequest().authenticated()
+                )
+
+                .formLogin(form -> form
+                        .usernameParameter("email")
+                        .passwordParameter("password")
+                        .defaultSuccessUrl("/swagger-ui/index.html", true)
+                        .permitAll()
+                )
+
+                .logout(logout -> logout
+                        .logoutUrl("/logout")
+                        .logoutSuccessUrl("/login?logout")
+                        .permitAll()
+                )
+
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(authenticationEntryPoint)     // 인증 실패 (401)
+                        .accessDeniedHandler(accessDeniedHandler)               // 인가 실패 (409)
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+
+        // BCrypt 방식으로 비밀번호 암호화
+        // 솔트 포함 해시 처리
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/umc/umc_10th/global/security/SecurityConfig.java
+++ b/src/main/java/com/umc/umc_10th/global/security/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
 
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(authenticationEntryPoint)     // 인증 실패 (401)
-                        .accessDeniedHandler(accessDeniedHandler)               // 인가 실패 (409)
+                        .accessDeniedHandler(accessDeniedHandler)               // 인가 실패 (403)
                 );
 
         return http.build();

--- a/src/main/java/com/umc/umc_10th/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/umc/umc_10th/global/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,37 @@
+package com.umc.umc_10th.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.umc_10th.global.apiPayLoad.ApiResponse;
+import com.umc.umc_10th.global.apiPayLoad.code.GeneralErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// 인가 실패
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException
+    ) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json; charset=utf-8");
+
+        ApiResponse<Object> apiResponse = ApiResponse.onFailure(
+                GeneralErrorCode.FORBIDDEN,
+                null
+        );
+
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/com/umc/umc_10th/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/umc/umc_10th/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.umc.umc_10th.global.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.umc_10th.global.apiPayLoad.ApiResponse;
+import com.umc.umc_10th.global.apiPayLoad.code.GeneralErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// 인증 실패
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json; charset=utf-8");
+
+        ApiResponse<Object> apiResponse = ApiResponse.onFailure(
+                GeneralErrorCode.UNAUTHORIZED,
+                null
+        );
+
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}


### PR DESCRIPTION
## 📄 작업 내용 요약
#36 
- [x]  Spring Security를 적용하고 회원가입 API를 구현
  - 폼 로그인을 위한 email, password를 추가로 받고 비밀번호는 BCrypt로 솔트처리
- [x] 회원가입 API는 Public API, 그 이외의 API는 Private API로 설정
  - Public API: 로그인 불필요 / Private API: 로그인 필요
  - exceptionHandling을 구현해 인증, 인가 실패 시 응답이 통일되야 함

---

## 🤔 피드백 받고 싶은 내용, 질문 사항
<!-- 미션 진행하면서 어려웠던 점이나 궁금했던 점 2-3개 이상 작성해주세요 -->

- point, is_active 속성의 기본값을 빌드 시 자동으로 설정하기 위해 `@Builder.Default`를 사용해서 구현했는데, 
Service 계층에서 객체 생성 시 `.point(0L)`처럼 명시적으로 값을 주입하는 방식과 비교했을 때 어떤 방법이 더 적절한지 궁금합니다.
- Spring Bean 주입 방식 대신 ObjectMapper new로 직접 객체를 생성해도 괜찮을까요?
---

## ✅ 작업 목록
회원가입 성공
<img width="2858" height="1282" alt="image" src="https://github.com/user-attachments/assets/6647bfe9-6ef9-49da-ba2a-f022a5dd0779" />
<img width="2832" height="1370" alt="image" src="https://github.com/user-attachments/assets/10013187-1959-4033-9be7-75c04dfd6c7e" />

비밀번호는 BCrypt로 솔트처리
<img width="1382" height="422" alt="image" src="https://github.com/user-attachments/assets/e928798a-1374-40c6-917d-1d322aa90071" />


검증 후 중복 시 403 에러 발생
<img width="2824" height="662" alt="image" src="https://github.com/user-attachments/assets/f2119401-1cd5-4abc-baa9-5af38861a7df" />
<img width="2814" height="636" alt="image" src="https://github.com/user-attachments/assets/abfd1adb-6f40-4386-b31a-6d12203e69a5" />

인가 401 에러
<img width="2830" height="682" alt="image" src="https://github.com/user-attachments/assets/f2437b46-f105-4fd9-9b28-75ec533bdca7" />

---

## 📝 기타 참고사항
<!-- 리뷰어가 참고하면 좋을 추가 정보나 질문이 있다면 자유롭게 작성해주세요 -->
